### PR TITLE
Update deploy workflow to remove build step

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,12 +18,6 @@ jobs:
       with:
         node-version: '16.x'
 
-    - name: Install dependencies
-      run: npm install
-
-    - name: Build website
-      run: npm run build
-
     - name: Deploy to IIS
       uses: webfactory/ssh-agent@v0.7.0
       with: 


### PR DESCRIPTION
## Description

The diff shows that the "Install dependencies" and "Build website" steps were removed from the deploy.yml workflow file. This implies the commit is updating the deploy workflow to no longer build the site locally, and instead likely deploy the built site directly from the GitHub action.


## Checklist

- [x] You have tested the changes locally and they work as expected
- [x] You have added appropriate documentation or updated existing documentation
- [x] You have followed the coding style and guidelines of the project
- [x] You have added/updated tests to ensure the changes are properly covered
- [x] You have reviewed the changes and ensured they meet the project's quality standards

## Screenshots (if applicable)

<!-- If your changes include any visual updates, provide screenshots here -->

## Additional Notes

<!-- Add any additional notes or context about the changes made in this pull request. -->